### PR TITLE
Fix uname return value condition for Illumos

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -33,7 +33,7 @@ impl PlatformInfo {
     pub fn new() -> io::Result<Self> {
         unsafe {
             let mut uts: utsname = mem::uninitialized();
-            if uname(&mut uts) == 0 {
+            if uname(&mut uts) != -1 {
                 Ok(Self { inner: uts })
             } else {
                 Err(io::Error::last_os_error())


### PR DESCRIPTION
https://illumos.org/man/2/uname

> Upon successful completion, a non-negative value is returned. Otherwise,
> -1 is returned and errno is set to indicate the error.

Other platforms:

1. [Linux](https://man7.org/linux/man-pages/man2/uname.2.html): On success, zero is returned.  On error, -1 is returned, and errno is set to indicate the error.
2. [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=uname&sektion=3&n=1): The uname() function returns the value 0 if successful; otherwise the value -1 is returned and the global variable errno	is set to indicate the error.
3. [macOS](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/uname.3.html): The uname() function returns the value 0 if successful; otherwise the value -1 is returned and the global variable errno is set to indicate the error.
4. [Solaris](https://docs.oracle.com/cd/E86824_01/html/E54765/uname-2.html): Upon successful completion, a non-negative value is returned. Otherwise, −1 is returned and errno is set to indicate the error.