### PR TITLE
Make dependencies platform specific

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ license = "MIT"
 [badges]
 appveyor = { repository = "uutils/platform-info" }
 
-[dependencies]
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 libc = "0.2"
+
+[target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "processthreadsapi", "sysinfoapi", "winbase", "winver"] }


### PR DESCRIPTION
- Made `winapi` dependency only for Windows
- Excluded `libc` dependency for Windows