### PR TITLE
WinOS fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
-* text=auto
+# v2022.06.23 [rivy]
+
+# default; use LF EOLs for text files
+* text=auto eol=lf
+
+# CRLF required; force required CRLF EOLs for WinOS BAT/CMD and MSVC SLN files
+*.[bB][aA][tT]    text eol=crlf
+*.[cC][mM][dD]    text eol=crlf
+*.[sS][lL][nN]    text eol=crlf

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -316,7 +316,7 @@ impl Uname for PlatformInfo {
 
         // XXX: if Rust ever works on Windows CE and winapi has the VER_PLATFORM_WIN32_CE
         //      constant, we should probably check for that
-        Cow::from("WindowsNT")
+        Cow::from("Windows_NT") // prior art from `busybox` and MS (from std::env::var("OS"))
     }
 
     fn nodename(&self) -> Cow<str> {
@@ -394,7 +394,8 @@ fn is_wow64() -> bool {
 
 #[test]
 fn test_sysname() {
-    assert_eq!(PlatformInfo::new().unwrap().sysname(), "WindowsNT");
+    let expected: String = std::env::var("OS").unwrap_or_else(|_| String::from("Windows_NT"));
+    assert_eq!(PlatformInfo::new().unwrap().sysname(), expected);
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,9 +16,9 @@ fn platform() -> Result<(), String> {
     assert!(!uname.sysname().is_empty());
     assert!(!uname.nodename().is_empty());
     assert!(!uname.release().is_empty());
-    #[cfg(not(windows))] // empty on windows
     assert!(!uname.version().is_empty());
     assert!(!uname.machine().is_empty());
+
     Ok(())
 }
 
@@ -34,7 +34,7 @@ fn platform_windows_specific() -> Result<(), String> {
     println!("release = {}", uname.release());
 
     assert!(!uname.nodename().is_empty());
-    //    assert!(!uname.version().is_empty());
+    assert!(!uname.version().is_empty());
     assert!(!uname.release().is_empty());
 
     Ok(())


### PR DESCRIPTION
These changes align the platform-info content more closely to other current implementations (ie, `busybox`):

1 - using the kernel system name of "Windows_NT" (used by multiple sources including `busybox` and MS [see ${OS}])
2 - release and version as defined by MS (see [NT Version Info (detailed)](https://en.wikipedia.org/wiki/Comparison_of_Microsoft_Windows_versions#Windows_NT) @@ <https://archive.is/FSkhj>)

With the changes, a platform-info result might be...

```text
sysname = Windows_NT
nodename = HOSTNAME
release = 10.0
version = 19045
machine = x86_64
```

And, with these changes incorporated, a (future) `uname -a` will look like:

```shell
> :: NOTE: equivalent to `busybox uname -a`
> uname -a
Windows_NT HOSTNAME 10.0 19044 x86_64 MS/Windows
```

The `version` format is debatable, but most references seem to refer to the single "build" portion of the full MS version as the "version". Some, like python, use a longer "version" which incorporates the "release" portion as well (eg, "10.0.19044"). I'm tending to follow the preponderance of use in reference material and the `busybox` method, but I'm open to the alternative if it's thought to be better.

Additionally, I've got a couple of further commits which add `osname()` to platform-info taking advantage of the already written WinOS version name calculation code (with a couple of updates; see PR #27). Then our uutils `uname -a` would ultimately look like:

```shell
> uname -a
Windows_NT HOSTNAME 10.0 19044 x86_64 MS/Windows (Windows 10)
```

This gives a `busybox`-like uname with a bit of extra useful information in the `osname` portion.

Thoughts? Changes?