### PR TITLE
Add `osname()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ fn main() {
     println!("{}", uname.release());
     println!("{}", uname.version());
     println!("{}", uname.machine());
+    println!("{}", uname.osname());
 }
 ```
 should return something like:
@@ -31,6 +32,7 @@ hostname
 5.10.0-8-amd64
 #1 SMP Debian 5.10.46-4 (2021-08-03)
 x86_64
+GNU/Linux
 ```
 
 License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,4 +56,29 @@ pub trait Uname {
 
     /// The name of the current system's hardware.
     fn machine(&self) -> Cow<str>;
+
+    /// The name of the current OS.
+    fn osname(&self) -> Cow<str>;
 }
+
+// private platform-specific HOST_OS_NAME * ref: [`uname` info](https://en.wikipedia.org/wiki/Uname)
+#[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "")))]
+const HOST_OS_NAME: &str = "GNU/Linux";
+#[cfg(all(target_os = "linux", not(any(target_env = "gnu", target_env = ""))))]
+const HOST_OS_NAME: &str = "Linux";
+#[cfg(target_os = "android")]
+const HOST_OS_NAME: &str = "Android";
+#[cfg(target_os = "windows")]
+pub const HOST_OS_NAME: &str = "MS/Windows"; // prior art == `busybox`
+#[cfg(target_os = "freebsd")]
+const HOST_OS_NAME: &str = "FreeBSD";
+#[cfg(target_os = "netbsd")]
+const HOST_OS_NAME: &str = "NetBSD";
+#[cfg(target_os = "openbsd")]
+const HOST_OS_NAME: &str = "OpenBSD";
+#[cfg(target_vendor = "apple")]
+const HOST_OS_NAME: &str = "Darwin";
+#[cfg(target_os = "fuchsia")]
+const HOST_OS_NAME: &str = "Fuchsia";
+#[cfg(target_os = "redox")]
+const HOST_OS_NAME: &str = "Redox";

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -70,3 +70,10 @@ impl Uname for PlatformInfo {
         Cow::Borrowed(crate::HOST_OS_NAME)
     }
 }
+
+#[test]
+fn test_osname() {
+    let info = PlatformInfo::new().unwrap();
+    println!("osname = '{}'", info.osname());
+    assert_eq!(PlatformInfo::new().unwrap().osname(), crate::HOST_OS_NAME);
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -65,4 +65,8 @@ impl Uname for PlatformInfo {
     fn machine(&self) -> Cow<str> {
         cstr2cow!(self.inner.machine)
     }
+
+    fn osname(&self) -> Cow<str> {
+        Cow::Borrowed(crate::HOST_OS_NAME)
+    }
 }

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -37,6 +37,10 @@ impl Uname for PlatformInfo {
     fn machine(&self) -> Cow<str> {
         Cow::Borrowed("unknown")
     }
+
+    fn osname(&self) -> Cow<str> {
+        Cow::Borrowed("unknown")
+    }
 }
 
 #[test]
@@ -48,4 +52,5 @@ fn test_unknown() {
     assert_eq!(platform_info.release(), "unknown");
     assert_eq!(platform_info.version(), "unknown");
     assert_eq!(platform_info.machine(), "unknown");
+    assert_eq!(platform_info.osname(), "unknown");
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -447,3 +447,10 @@ fn test_machine() {
     println!("{}", info.machine());
     assert!(target.contains(&&*info.machine()));
 }
+
+#[test]
+fn test_osname() {
+    let info = PlatformInfo::new().unwrap();
+    println!("osname = '{}'", info.osname());
+    assert!(info.osname().starts_with(crate::HOST_OS_NAME));
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -141,7 +141,7 @@ impl PlatformInfo {
                             osinfo.dwMinorVersion,
                             osinfo.dwBuildNumber,
                             osinfo.wProductType,
-                            osinfo.wSuiteMask,
+                            osinfo.wSuiteMask.into(),
                         ),
                         release: format!("{}.{}", osinfo.dwMajorVersion, osinfo.dwMinorVersion),
                         version: format!("{}", osinfo.dwBuildNumber),
@@ -172,7 +172,7 @@ impl PlatformInfo {
 
         let mask = unsafe { sysinfoapi::VerSetConditionMask(0, VER_SUITENAME, VER_EQUAL) };
         let suite_mask = if unsafe { VerifyVersionInfoW(&mut info, VER_SUITENAME, mask) } != 0 {
-            VER_SUITE_WH_SERVER as USHORT
+            VER_SUITE_WH_SERVER
         } else {
             0
         };
@@ -245,7 +245,7 @@ impl PlatformInfo {
         }
     }
 
-    fn query_version_info(buffer: Vec<u8>) -> io::Result<(ULONG, ULONG, ULONG, ULONG)> {
+    fn query_version_info(buffer: Vec<u8>) -> io::Result<(DWORD, DWORD, DWORD, DWORD)> {
         let mut block_size = 0;
         let mut block = ptr::null_mut();
 
@@ -277,11 +277,11 @@ impl PlatformInfo {
     }
 
     fn determine_os_name(
-        major: ULONG,
-        minor: ULONG,
-        build: ULONG,
-        product_type: UCHAR,
-        suite_mask: USHORT,
+        major: DWORD,
+        minor: DWORD,
+        build: DWORD,
+        product_type: BYTE,
+        suite_mask: DWORD,
     ) -> String {
         // [NT Version Info (detailed)](https://en.wikipedia.org/wiki/Comparison_of_Microsoft_Windows_versions#Windows_NT) @@ <https://archive.is/FSkhj>
         let default_name = if product_type == VER_NT_WORKSTATION {
@@ -295,7 +295,7 @@ impl PlatformInfo {
                 0 => "Windows 2000",
                 1 => "Windows XP",
                 2 if product_type == VER_NT_WORKSTATION => "Windows XP Professional x64 Edition",
-                2 if suite_mask as UINT == VER_SUITE_WH_SERVER => "Windows Home Server",
+                2 if suite_mask == VER_SUITE_WH_SERVER => "Windows Home Server",
                 2 => "Windows Server 2003",
                 _ => &default_name,
             },

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -417,8 +417,10 @@ fn is_wow64() -> bool {
 
 #[test]
 fn test_sysname() {
+    let info = PlatformInfo::new().unwrap();
     let expected: String = std::env::var("OS").unwrap_or_else(|_| String::from("Windows_NT"));
-    assert_eq!(PlatformInfo::new().unwrap().sysname(), expected);
+    println!("sysname = '{}'", info.sysname());
+    assert_eq!(info.sysname(), expected);
 }
 
 #[test]
@@ -444,7 +446,7 @@ fn test_machine() {
 
     let info = PlatformInfo::new().unwrap();
 
-    println!("{}", info.machine());
+    println!("machine = '{}'", info.machine());
     assert!(target.contains(&&*info.machine()));
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -478,3 +478,116 @@ fn test_version_vs_version() {
             < 1000
     );
 }
+
+#[test]
+fn test_known_os_names() {
+    // ref: [NT Version Info (detailed)](https://en.wikipedia.org/wiki/Comparison_of_Microsoft_Windows_versions#Windows_NT) @@ <https://archive.is/FSkhj>
+    assert_eq!(
+        PlatformInfo::determine_os_name(3, 1, 528, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 3.1"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(3, 5, 807, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 3.5"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(3, 51, 1057, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 3.51"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(4, 0, 1381, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 4.0"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(5, 0, 2195, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 2000"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(5, 1, 2600, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows XP"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(5, 2, 3790, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows XP Professional x64 Edition"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(5, 2, 3790, VER_NT_SERVER, VER_SUITE_WH_SERVER),
+        "Windows Home Server"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(5, 2, 3790, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2003"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(5, 2, 3790, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2003"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(6, 0, 6000, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows Vista"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(6, 0, 6001, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2008"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(6, 1, 7600, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 7"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(6, 1, 7600, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2008 R2"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(6, 2, 9200, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2012"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(6, 2, 9200, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 8"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(6, 3, 9600, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 8.1"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(6, 3, 9600, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2012 R2"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 10240, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 10"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 17134, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 10"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 19141, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 10"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 19145, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 10"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 14393, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2016"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 17763, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2019"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 20348, VER_NT_SERVER, VER_SUITE_SMALLBUSINESS),
+        "Windows Server 2022"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 22000, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 11"
+    );
+    assert_eq!(
+        PlatformInfo::determine_os_name(10, 0, 22621, VER_NT_WORKSTATION, VER_SUITE_PERSONAL),
+        "Windows 11"
+    );
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -64,6 +64,7 @@ pub struct PlatformInfo {
     nodename: String,
     release: String,
     version: String,
+    osname: String,
 }
 
 impl PlatformInfo {
@@ -85,6 +86,7 @@ impl PlatformInfo {
                 nodename,
                 version: version_info.version,
                 release: version_info.release,
+                osname: format!("{} ({})", crate::HOST_OS_NAME, version_info.os_name),
             })
         }
     }
@@ -360,6 +362,10 @@ impl Uname for PlatformInfo {
         };
 
         Cow::from(arch_str)
+    }
+
+    fn osname(&self) -> Cow<str> {
+        Cow::from(self.osname.as_str())
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -426,7 +426,8 @@ fn test_sysname() {
 
 #[test]
 fn test_machine() {
-    let target = if cfg!(target_arch = "x86_64") || (cfg!(target_arch = "x86") && is_wow64()) {
+    let is_wow64 = is_wow64();
+    let target = if cfg!(target_arch = "x86_64") || (cfg!(target_arch = "x86") && is_wow64) {
         vec!["x86_64"]
     } else if cfg!(target_arch = "x86") {
         vec!["i386", "i486", "i586", "i686"]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -311,10 +311,10 @@ impl PlatformInfo {
             },
             10 => match minor {
                 0 if product_type == VER_NT_WORKSTATION && (build >= 22000) => "Windows 11",
-                0 if product_type != VER_NT_WORKSTATION && (build >= 14000 && build < 17000) => {
+                0 if product_type != VER_NT_WORKSTATION && (14000..17000).contains(&build) => {
                     "Windows Server 2016"
                 }
-                0 if product_type != VER_NT_WORKSTATION && (build >= 17000 && build < 19000) => {
+                0 if product_type != VER_NT_WORKSTATION && (17000..19000).contains(&build) => {
                     "Windows Server 2019"
                 }
                 0 if product_type != VER_NT_WORKSTATION && (build >= 20000) => {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -53,6 +53,7 @@ struct VS_FIXEDFILEINFO {
     dwFileDateLS: DWORD,
 }
 
+#[derive(Debug)]
 struct WinOSVersionInfo {
     os_name: String,
     release: String,
@@ -455,4 +456,24 @@ fn test_osname() {
     let info = PlatformInfo::new().unwrap();
     println!("osname = '{}'", info.osname());
     assert!(info.osname().starts_with(crate::HOST_OS_NAME));
+}
+
+#[test]
+fn test_version_vs_version() {
+    let version_via_dll = unsafe { PlatformInfo::version_info().unwrap() };
+    let version_via_file = PlatformInfo::version_info_from_file().unwrap();
+
+    println!("version (via dll) = '{:#?}'", version_via_dll);
+    println!("version (via file) = '{:#?}'", version_via_file);
+
+    assert_eq!(version_via_dll.os_name, version_via_file.os_name);
+    assert_eq!(version_via_dll.release, version_via_file.release);
+    // the "version" portions may differ, but should have only slight variation
+    // * assume that "version" is convertible to u32 + "version" from file is always earlier/smaller and may differ only below the thousands digit
+    // * ref: [NT Version Info (detailed)](https://en.wikipedia.org/wiki/Comparison_of_Microsoft_Windows_versions#Windows_NT) @@ <https://archive.is/FSkhj>
+    assert!(
+        (version_via_dll.version.parse::<u32>().unwrap()
+            - version_via_file.version.parse::<u32>().unwrap())
+            < 1000
+    );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23,21 +23,3 @@ fn platform() -> Result<(), String> {
 
     Ok(())
 }
-
-#[cfg(windows)]
-#[test]
-fn platform_windows_specific() -> Result<(), String> {
-    let uname = match PlatformInfo::new() {
-        Ok(info) => info,
-        Err(error) => panic!("{}", error),
-    };
-    println!("computer_name = {}", uname.nodename());
-    println!("version = {}", uname.version());
-    println!("release = {}", uname.release());
-
-    assert!(!uname.nodename().is_empty());
-    assert!(!uname.version().is_empty());
-    assert!(!uname.release().is_empty());
-
-    Ok(())
-}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,12 +7,12 @@ fn platform() -> Result<(), String> {
         Err(error) => panic!("{}", error),
     };
 
-    println!("sysname = {}", uname.sysname());
-    println!("nodename = {}", uname.nodename());
-    println!("release = {}", uname.release());
-    println!("version = {}", uname.version());
-    println!("machine = {}", uname.machine());
-    println!("osname = {}", uname.osname());
+    println!("sysname = '{}'", uname.sysname());
+    println!("nodename = '{}'", uname.nodename());
+    println!("release = '{}'", uname.release());
+    println!("version = '{}'", uname.version());
+    println!("machine = '{}'", uname.machine());
+    println!("osname = '{}'", uname.osname());
 
     assert!(!uname.sysname().is_empty());
     assert!(!uname.nodename().is_empty());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,12 +12,14 @@ fn platform() -> Result<(), String> {
     println!("release = {}", uname.release());
     println!("version = {}", uname.version());
     println!("machine = {}", uname.machine());
+    println!("osname = {}", uname.osname());
 
     assert!(!uname.sysname().is_empty());
     assert!(!uname.nodename().is_empty());
     assert!(!uname.release().is_empty());
     assert!(!uname.version().is_empty());
     assert!(!uname.machine().is_empty());
+    assert!(!uname.osname().is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
This is on top of PR https://github.com/uutils/platform-info/pull/26 (see the [changes](https://github.com/rivy/rs.platform-info/compare/fix.winos...rivy:rs.platform-info:add.osname); I'll rebase with #26 is merged).

Move `osname()` calculation down from uutils `uname` into platform-info to reduce `uname` complexity and add additional WinOS info to the result.

With this and updates to `uname`, a future `uname -a` would look like...

```shell
> uname -a
Windows_NT HOSTNAME 10.0 19044 x86_64 MS/Windows (Windows 10)
```
