### PR TITLE
WinOS: fixes nodename calculation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "processthreadsapi", "sysinfoapi", "winbase", "winver"] }
+
+[dev-dependencies]
+regex = "1"

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -26,6 +26,7 @@ use self::winapi::um::winnt::*;
 use self::winapi::um::winver::*;
 use super::Uname;
 use std::borrow::Cow;
+use std::convert::TryFrom;
 use std::ffi::{CStr, OsStr, OsString};
 use std::io;
 use std::iter;
@@ -105,7 +106,9 @@ impl PlatformInfo {
         let mut data: Vec<u16> = vec![0; size as usize];
         unsafe {
             if GetComputerNameExW(ComputerNameDnsHostname, data.as_mut_ptr(), &mut size) != 0 {
-                Ok(String::from_utf16_lossy(&data))
+                Ok(String::from_utf16_lossy(
+                    &data[..usize::try_from(size).unwrap()],
+                ))
             } else {
                 // XXX: should this error or just return localhost?
                 Err(io::Error::last_os_error())

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -425,6 +425,15 @@ fn test_sysname() {
 }
 
 #[test]
+#[allow(non_snake_case)]
+fn test_nodename_no_trailing_NUL() {
+    let info = PlatformInfo::new().unwrap();
+    let nodename = info.nodename();
+    let trimmed = nodename.trim().trim_end_matches(|c| c == '\0');
+    assert_eq!(nodename, trimmed);
+}
+
+#[test]
 fn test_machine() {
     let is_wow64 = is_wow64();
     let target = if cfg!(target_arch = "x86_64") || (cfg!(target_arch = "x86") && is_wow64) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,18 +1,26 @@
+// spell-checker:ignore (API) nodename osname sysname
+
+use regex;
+
 use platform_info::*;
 
 #[test]
 fn platform() -> Result<(), String> {
-    let uname = match PlatformInfo::new() {
-        Ok(info) => info,
-        Err(error) => panic!("{}", error),
-    };
+    let uname = PlatformInfo::new().unwrap();
 
-    println!("sysname = '{}'", uname.sysname());
-    println!("nodename = '{}'", uname.nodename());
-    println!("release = '{}'", uname.release());
-    println!("version = '{}'", uname.version());
-    println!("machine = '{}'", uname.machine());
-    println!("osname = '{}'", uname.osname());
+    let sysname = uname.sysname();
+    let nodename = uname.nodename();
+    let release = uname.release();
+    let version = uname.version();
+    let machine = uname.machine();
+    let osname = uname.osname();
+
+    println!("sysname = [{}]'{}'", sysname.len(), sysname);
+    println!("nodename = [{}]'{}'", nodename.len(), nodename);
+    println!("release = [{}]'{}'", release.len(), release);
+    println!("version = [{}]'{}'", version.len(), version);
+    println!("machine = [{}]'{}'", machine.len(), machine);
+    println!("osname = [{}]'{}'", osname.len(), osname);
 
     assert!(!uname.sysname().is_empty());
     assert!(!uname.nodename().is_empty());
@@ -20,6 +28,27 @@ fn platform() -> Result<(), String> {
     assert!(!uname.version().is_empty());
     assert!(!uname.machine().is_empty());
     assert!(!uname.osname().is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn platform_no_invisible_contents() -> Result<(), String> {
+    let uname = PlatformInfo::new().unwrap();
+
+    let sysname = uname.sysname();
+    let nodename = uname.nodename();
+    let release = uname.release();
+    let version = uname.version();
+    let machine = uname.machine();
+    let osname = uname.osname();
+
+    let s = format!("sysname='{sysname}';nodename='{nodename}';release='{release}';version='{version}';machine='{machine}';osname={osname}");
+    println!("s = [{}]\"{}\"", s.len(), s);
+
+    // let re = regex::Regex::new("[^[[:print:]]]").unwrap(); // matches invisible (and emojis)
+    let re = regex::Regex::new("[^[[:print:]]\\p{Other_Symbol}]").unwrap(); // matches invisible only (not emojis)
+    assert_eq!(re.find(&s), None);
 
     Ok(())
 }


### PR DESCRIPTION
This adds tests and fixes the extraneous NUL character suffix for the WinOS nodename calculation.

Fixes #32.