### PR TITLE
Refactor API/Errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,15 +34,32 @@ use of every feature.
 use std::ffi::OsStr;
 
 mod lib_impl;
-pub use lib_impl::*;
 
 //===
 
-pub type PlatformInfoError = BoxedThreadSafeStdError;
+// PlatformInfo
+/// Handles initial retrieval and holds cached information for the current platform.
+pub type PlatformInfo = lib_impl::PlatformInfo;
 
-/// `PlatformInfoAPI` defines a trait API providing `uname` (aka "Unix name") style platform information.
+// PlatformInfoError
+/// The common error type for `PlatformInfo`.
+pub type PlatformInfoError = lib_impl::BoxedThreadSafeStdError;
+
+// PlatformInfoAPI
+/// Defines the full API for `PlatformInfo`.
+// * includes `UNameAPI`
+pub trait PlatformInfoAPI: UNameAPI {
+    /// Creates a new instance of `PlatformInfo`.
+    /// <br> On some platforms, it is possible for this function to fail.
+    fn new() -> Result<Self, PlatformInfoError>
+    where
+        Self: Sized;
+}
+
+// UNameAPI
+/// Defines a trait API providing `uname` (aka "Unix name") style platform information.
 // ref: <https://www.gnu.org/software/libc/manual/html_node/Platform-Type.html> @@ <https://archive.is/YjjWJ>
-pub trait PlatformInfoAPI {
+pub trait UNameAPI {
     /// The name of this implementation of the operating system.
     fn sysname(&self) -> &OsStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,10 @@ use std::ffi::OsStr;
 mod lib_impl;
 pub use lib_impl::*;
 
+//===
+
+pub type PlatformInfoError = BoxedThreadSafeStdError;
+
 /// `PlatformInfoAPI` defines a trait API providing `uname` (aka "Unix name") style platform information.
 // ref: <https://www.gnu.org/software/libc/manual/html_node/Platform-Type.html> @@ <https://archive.is/YjjWJ>
 pub trait PlatformInfoAPI {

--- a/src/lib_impl.rs
+++ b/src/lib_impl.rs
@@ -5,6 +5,11 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+//=== types
+
+pub type ThreadSafeStdError = dyn std::error::Error + Send + Sync;
+pub type BoxedThreadSafeStdError = Box<ThreadSafeStdError>;
+
 /// A slice of a path string
 /// (akin to [`str`]; aka/equivalent to [`Path`]).
 pub type PathStr = Path;

--- a/src/lib_impl.rs
+++ b/src/lib_impl.rs
@@ -2,7 +2,9 @@
 
 #![warn(unused_results)]
 
+#[cfg(target_os = "windows")]
 use std::path::Path;
+#[cfg(target_os = "windows")]
 use std::path::PathBuf;
 
 //=== types
@@ -12,16 +14,18 @@ pub type BoxedThreadSafeStdError = Box<ThreadSafeStdError>;
 
 /// A slice of a path string
 /// (akin to [`str`]; aka/equivalent to [`Path`]).
-pub type PathStr = Path;
+#[cfg(target_os = "windows")]
+type PathStr = Path;
 /// An owned, mutable path string
 /// (akin to [`String`]; aka/equivalent to [`PathBuf`]).
-pub type PathString = PathBuf;
+#[cfg(target_os = "windows")]
+type PathString = PathBuf;
 
 //=== platform-specific const
 
 // HOST_OS_NAME * ref: [`uname` info](https://en.wikipedia.org/wiki/Uname)
 #[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "")))]
-pub const HOST_OS_NAME: &str = "GNU/Linux";
+const HOST_OS_NAME: &str = "GNU/Linux";
 #[cfg(all(target_os = "linux", not(any(target_env = "gnu", target_env = ""))))]
 pub const HOST_OS_NAME: &str = "Linux";
 #[cfg(target_os = "android")]
@@ -40,6 +44,8 @@ pub const HOST_OS_NAME: &str = "Darwin";
 pub const HOST_OS_NAME: &str = "Fuchsia";
 #[cfg(target_os = "redox")]
 pub const HOST_OS_NAME: &str = "Redox";
+#[cfg(not(any(unix, windows)))]
+pub const HOST_OS_NAME: &str = "unknown";
 
 //=== platform-specific module code
 

--- a/src/platform/unknown.rs
+++ b/src/platform/unknown.rs
@@ -11,27 +11,26 @@
 
 #![warn(unused_results)]
 
-use std::error::Error;
 use std::ffi::{OsStr, OsString};
 
-use crate::PlatformInfoAPI;
+use crate::{PlatformInfoAPI, PlatformInfoError, UNameAPI};
 
 // PlatformInfo
-/// Handles initial retrieval and holds information for the current platform ("unknown" in this case).
+/// Handles initial retrieval and holds cached information for the current platform ("unknown" in this case).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlatformInfo {
     unknown: OsString,
 }
 
-impl PlatformInfo {
-    pub fn new() -> Result<Self, Box<dyn Error>> {
+impl PlatformInfoAPI for PlatformInfo {
+    fn new() -> Result<Self, PlatformInfoError> {
         Ok(Self {
-            unknown: OsString::from("unknown"),
+            unknown: OsString::from(crate::lib_impl::HOST_OS_NAME),
         })
     }
 }
 
-impl PlatformInfoAPI for PlatformInfo {
+impl UNameAPI for PlatformInfo {
     fn sysname(&self) -> &OsStr {
         &self.unknown
     }


### PR DESCRIPTION
The public API is refined and now completely described within *lib.rs*.

- `PlatformInfoAPI` now contains the entire public API (prominently adding `new()`).
- `UNameAPI` is included as the named subset of the API for `uname()` property access.
- Errors have been refactored to improve clarity and intent, formalizing thread-safety and laying the groundwork for further improvements (ie, using `error-stack`).

Any API changes are expansions or formalizing non-public portions and should be non-breaking for usual usage. And since its a patch on the initial 2.0 release, I think we can just include this in a `2.0.1` release with the BSD-like fix. Otherwise, we could release both together as a `3.0` release.