### PR TITLE
tests ~ add fail point instrumentation/testing (coverage => 100%)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,14 @@ libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "processthreadsapi", "sysinfoapi", "winbase", "winver"] }
 
+[dependencies]
+fail="0.5"
+function_name="0.3"
+serial_test="1"
+
 [dev-dependencies]
 regex = "1"
+
+[features]
+default = []
+feat_failpoints = ["fail/failpoints"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["platform", "info", "system"]
 categories = ["os"]
 license = "MIT"
 
-# spell-checker:ignore (crates) libc winapi (features) libloaderapi processthreadsapi sysinfoapi winbase winver
+# spell-checker:ignore (crates) libc winapi (features) failpoints libloaderapi processthreadsapi sysinfoapi winbase winver
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 libc = "0.2"

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -217,3 +217,9 @@ fn structure_clone() {
     let info_copy = info.clone();
     assert_eq!(info_copy, info);
 }
+
+#[test]
+fn test_utsname() {
+    let result = utsname();
+    assert!(result.is_ok());
+}

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -8,7 +8,7 @@
 
 // spell-checker:ignore (API) domainname nodename osname sysname
 // spell-checker:ignore (libc) libc utsname
-// spell-checker:ignore (jargon) hasher
+// spell-checker:ignore (jargon) failpoint failpoints hasher
 // spell-checker:ignore (names) Jian Zeng * anonymousknight96
 // spell-checker:ignore (rust) uninit
 // spell-checker:ignore (uutils) coreutils uutils

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -778,3 +778,25 @@ fn structure_clone() {
     let fvi_clone = fvi.clone();
     assert_eq!(fvi_clone, fvi);
 }
+
+#[test]
+#[allow(non_snake_case)]
+fn test_WinOsGetComputerName() {
+    let result = WinOsGetComputerName();
+    assert!(result.is_ok());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_WinOsFileVersionInfo() {
+    let file_path = WinOsGetSystemDirectory().unwrap().join("kernel32.dll");
+    let result = WinOsGetFileVersionInfo(&file_path);
+    assert!(result.is_ok());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_WinOsGetSystemDirectory() {
+    let result = WinOsGetSystemDirectory();
+    assert!(result.is_ok());
+}

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -553,36 +553,30 @@ fn test_nodename_no_trailing_NUL() {
 
 #[test]
 fn test_machine() {
-    let is_wow64 = KERNEL32_IsWow64Process(WinAPI_GetCurrentProcess()).unwrap_or_else(|err| {
-        println!("ERR: IsWow64Process(): {:#?}", err);
-        false
-    });
-
-    let target = if cfg!(target_arch = "x86_64") || (cfg!(target_arch = "x86") && is_wow64) {
-        vec!["x86_64"]
-    } else if cfg!(target_arch = "x86") {
-        vec!["i386", "i486", "i586", "i686"]
-    } else if cfg!(target_arch = "arm") {
-        vec!["arm"]
-    } else if cfg!(target_arch = "aarch64") {
-        // NOTE: keeping both of these until the correct behavior is sorted out
-        vec!["arm64", "aarch64"]
-    } else if cfg!(target_arch = "powerpc") {
-        vec!["powerpc"]
-    } else if cfg!(target_arch = "mips") {
-        vec!["mips"]
-    } else {
-        // NOTE: the other architecture are currently not valid targets for Rust (in fact, I am
-        //       almost certain some of these are not even valid targets for the Windows build)
-        vec!["unknown"]
-    };
-    println!("target={:#?}", target);
+    #[allow(unused_assignments)] // suppress false-positive
+    #[allow(unused_mut)] // suppress; need for `mut` is dependent on target_arch
+    let mut expected = vec![std::env::consts::ARCH];
+    // expected is correct for "arm", "aarch64" and "x86_64"
+    // * [cfg(target_arch = "arm")] ... vec!["arm"]
+    // * [cfg(target_arch = "aarch64")] ... vec!["aarch64" /* , "arm64" */] // "aarch64" == "arm64" for WinOS
+    // * [cfg(target_arch = "x86_64")] ... vec!["x86_64" /* , "amd64" */] // "x86_64" == "amd64" for WinOS
+    #[cfg(target_arch = "x86")]
+    {
+        let is_wow64 = KERNEL32_IsWow64Process(WinAPI_GetCurrentProcess()).unwrap();
+        expected = if is_wow64 {
+            vec!["x86_64"]
+        } else {
+            vec!["i386", "i486", "i586", "i686"]
+        };
+    }
+    // note: [2023-05] any alternate architectures are likely impossible targets for Rust/WinOS
+    println!("expected={:#?}", expected);
 
     let info = PlatformInfo::new().unwrap();
     let machine = info.machine().to_string_lossy();
     println!("machine=[{}]'{}'", machine.len(), machine);
 
-    assert!(target.contains(&&machine[..]));
+    assert!(expected.contains(&&machine[..]));
 }
 
 #[test]
@@ -597,7 +591,7 @@ fn test_osname() {
 fn test_version_vs_version() {
     let version_via_dll = os_version_info_from_dll().unwrap();
     let version_via_file = version_info_from_file::<_, &str>(None).unwrap();
-    assert!(version_via_file == version_info_from_file("").unwrap());
+    assert!(version_via_file == version_info_from_file("" /* default file */).unwrap());
 
     println!("version (via dll) = '{:#?}'", version_via_dll);
     println!("version (via known file) = '{:#?}'", version_via_file);
@@ -618,6 +612,7 @@ fn test_version_vs_version() {
         .parse::<u32>()
         .unwrap();
     assert!(version_via_dll_n.checked_sub(version_via_file_n) < Some(1000));
+    assert!(version_via_dll_n.checked_sub(version_via_file_n) >= Some(0));
 }
 
 #[test]
@@ -754,8 +749,17 @@ fn test_known_winos_names() {
 fn structure_clone() {
     let info = PlatformInfo::new().unwrap();
     println!("{:?}", info);
-    let info_copy = info.clone();
-    assert_eq!(info_copy, info);
+    let info_clone = info.clone();
+    assert_eq!(info_clone, info);
+
+    // WinApiSystemInfo
+    #[allow(clippy::clone_on_copy)] // ignore warning for direct testing of `clone()` method
+    let si_clone = info.system_info.clone();
+    assert_eq!(si_clone, info.system_info);
+
+    // WinOsVersionInfo
+    let vi_clone = info.version_info.clone();
+    assert_eq!(vi_clone, info.version_info);
 
     let mmbr = MmbrVersion {
         major: 1,
@@ -764,13 +768,13 @@ fn structure_clone() {
         release: 4,
     };
     println!("{:?}", mmbr);
-    let mmbr_copy = mmbr.clone();
-    assert_eq!(mmbr_copy, mmbr);
+    let mmbr_clone = mmbr.clone();
+    assert_eq!(mmbr_clone, mmbr);
 
     let fvi = WinApiFileVersionInfo {
         data: vec![1, 2, 3, 4],
     };
     println!("{:?}", fvi);
-    let fvi_copy = fvi.clone();
-    assert_eq!(fvi_copy, fvi);
+    let fvi_clone = fvi.clone();
+    assert_eq!(fvi_clone, fvi);
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -489,21 +489,25 @@ fn determine_machine(system_info: &WinApiSystemInfo) -> OsString {
     // ref: [LLVM Triples](https://llvm.org/doxygen/classllvm_1_1Triple.html) @@ <https://archive.is/MwVL8>
     // ref: [SuperH](https://en.wikipedia.org/wiki/SuperH) @@ <https://archive.is/ckr6a>
     // ref: [OldNewThing ~ SuperH](https://devblogs.microsoft.com/oldnewthing/20190805-00/?p=102749) @@ <https://archive.is/KWlyV>
+    // ref: [SYSTEM_PROCESSOR_INFORMATION documented](https://masm32.com/board/index.php?topic=3401.0) @@ <https://archive.is/hGfxz>
+    // NOTE: architecture names generally correspond to GNU and Rust practices
     let arch_str = match arch {
-        PROCESSOR_ARCHITECTURE_AMD64 => "x86_64",
+        PROCESSOR_ARCHITECTURE_AMD64 => "x86_64", // aka "amd64" for WinOS
         PROCESSOR_ARCHITECTURE_INTEL => match system_info.0.wProcessorLevel {
             4 => "i486",
             5 => "i586",
             6 => "i686",
             _ => "i386",
         },
-        PROCESSOR_ARCHITECTURE_IA64 => "ia64",
-        PROCESSOR_ARCHITECTURE_ARM => "arm", // `arm` may be under-specified compared to GNU implementations
-        PROCESSOR_ARCHITECTURE_ARM64 => "aarch64", // alternatively, `arm64` may be more correct
+        // * WinOS has only bare-bones specification for ARM processors
+        PROCESSOR_ARCHITECTURE_ARM => "arm",
+        PROCESSOR_ARCHITECTURE_ARM64 => "aarch64", // aka "arm64" for WinOS
+        // * [2023-05] enumerated but likely impossible target architectures for Rust/WinOS
+        PROCESSOR_ARCHITECTURE_ALPHA | PROCESSOR_ARCHITECTURE_ALPHA64 => "alpha",
+        PROCESSOR_ARCHITECTURE_IA64 => "ia64", // Intel Itanium
         PROCESSOR_ARCHITECTURE_MIPS => "mips",
         PROCESSOR_ARCHITECTURE_PPC => "powerpc",
-        PROCESSOR_ARCHITECTURE_ALPHA | PROCESSOR_ARCHITECTURE_ALPHA64 => "alpha",
-        PROCESSOR_ARCHITECTURE_SHX => "superh", // a "SuperH" processor
+        PROCESSOR_ARCHITECTURE_SHX => "sh", // a "SuperH" processor
         _ => "unknown",
     };
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -21,9 +21,9 @@
 
 // spell-checker:ignore (abbrev/acronyms) MSVC POSIX SuperH
 // spell-checker:ignore (API) sysname osname nodename
-// spell-checker:ignore (jargon) armv aarch hasher mmbr
+// spell-checker:ignore (jargon) armv aarch failpoints hasher mmbr
 // spell-checker:ignore (people) Roy Ivy III * rivy
-// spell-checker:ignore (rust) repr stdcall uninit
+// spell-checker:ignore (rust) consts repr stdcall uninit
 // spell-checker:ignore (uutils) coreutils uutils
 // spell-checker:ignore (WinAPI) ctypes CWSTR DWORDLONG dwStrucVersion FARPROC FIXEDFILEINFO HIWORD HMODULE libloaderapi LOWORD LPCSTR LPCVOID LPCWSTR lpdw LPDWORD lplp LPOSVERSIONINFOEXW LPSYSTEM lptstr LPVOID LPWSTR minwindef ntdef ntstatus OSVERSIONINFOEXW processthreadsapi PUINT SMALLBUSINESS SUITENAME sysinfo sysinfoapi sysinfoapi TCHAR TCHARs ULONGLONG VERSIONINFO WCHAR WCHARs winapi winbase winver WSTR wstring
 // spell-checker:ignore (WinOS) ntdll

--- a/src/platform/windows_safe.rs
+++ b/src/platform/windows_safe.rs
@@ -607,7 +607,11 @@ pub fn NTDLL_RtlGetVersion() -> Result<OSVERSIONINFOEXW, WinOSError> {
 
 //=== Tests
 
+#[cfg(test)]
+use serial_test::{parallel, serial};
+
 #[test]
+#[parallel]
 fn structure_clone() {
     let ffi = VS_FIXEDFILEINFO {
         dwSignature: 0,
@@ -630,29 +634,86 @@ fn structure_clone() {
     assert_eq!(ffi_clone, ffi);
 }
 
+// #[allow(dead_code)]
+// #[cfg_attr(feature = "feat_failpoints", test)]
+// #[cfg_attr(not(feature = "feat_failpoints"), ignore = "test disappears", serial)]
+// fn test_fail_point_disappears() {
+//     let _guard = fail::FailGuard::new("WinApiSystemInfo::wProcessorArchitecture", "return(1001)");
+//     println!("{:?}", fail::list());
+//     let system_info = WinApiSystemInfo(WinAPI_GetNativeSystemInfo());
+//     let result = system_info.wProcessorArchitecture();
+//     println!("{:#?}", system_info);
+//     assert_eq!(result, 1001);
+// }
+
 #[test]
 #[allow(non_snake_case)]
+#[serial]
+#[cfg_attr(
+    not(feature = "feat_failpoints"),
+    ignore = "requires 'feat_failpoints'"
+)]
 fn test_create_OSVERSIONINFOEXW() {
     let result = create_OSVERSIONINFOEXW();
     assert!(result.is_ok());
+    {
+        let _guard = fail::FailGuard::new("create_OSVERSIONINFOEXW", "return");
+        let result = create_OSVERSIONINFOEXW();
+        assert!(result.is_err());
+    }
 }
 
 #[test]
 #[allow(non_snake_case)]
+#[serial]
+#[cfg_attr(
+    not(feature = "feat_failpoints"),
+    ignore = "requires 'feat_failpoints'"
+)]
 fn test_WinAPI_GetCurrentProcess() {
     let result = WinAPI_GetCurrentProcess();
     assert_ne!(ptr::null_mut(), result);
+    {
+        let _guard = fail::FailGuard::new("WinAPI_GetCurrentProcess", "return");
+        let result = WinAPI_GetCurrentProcess();
+        assert_eq!(ptr::null_mut(), result);
+    }
 }
 
 #[test]
 #[allow(non_snake_case)]
+#[serial]
+#[cfg_attr(
+    not(feature = "feat_failpoints"),
+    ignore = "requires 'feat_failpoints'"
+)]
 fn test_WinAPI_LoadLibrary() {
     let result = WinAPI_LoadLibrary("");
     assert_eq!(ptr::null_mut(), result);
+    {
+        let _guard = fail::FailGuard::new("WinAPI_LoadLibrary", "off");
+        let result = WinAPI_LoadLibrary("");
+        assert_eq!(ptr::null_mut(), result);
+    }
+    {
+        let _guard = fail::FailGuard::new("WinAPI_LoadLibrary", "return");
+        let result = WinAPI_LoadLibrary("");
+        assert_eq!(ptr::null_mut(), result);
+    }
+    {
+        let _guard = fail::FailGuard::new("WinAPI_LoadLibrary", "return(nonsense)");
+        let result = WinAPI_LoadLibrary("");
+        assert_eq!(ptr::null_mut(), result);
+    }
 }
 
 #[test]
 #[allow(non_snake_case)]
+#[serial]
+#[cfg_attr(
+    not(feature = "feat_failpoints"),
+    ignore = "requires 'feat_failpoints'"
+)]
 fn test_WinOsFileVersionInfoQuery_root() {
     let file_path = super::WinOsGetSystemDirectory()
         .unwrap()
@@ -661,18 +722,73 @@ fn test_WinOsFileVersionInfoQuery_root() {
 
     let result = WinOsFileVersionInfoQuery_root(&file_info);
     assert!(result.is_ok());
+    {
+        let _guard = fail::FailGuard::new("WinOsFileVersionInfoQuery_root", "return");
+        let result = WinOsFileVersionInfoQuery_root(&file_info);
+        assert!(result.is_err());
+    }
+    {
+        let _guard = fail::FailGuard::new("WinAPI_VerQueryValueW", "return");
+        let result = WinOsFileVersionInfoQuery_root(&file_info);
+        assert!(result.is_err());
+    }
 }
 
 #[test]
 #[allow(non_snake_case)]
+#[serial]
+#[cfg_attr(
+    not(feature = "feat_failpoints"),
+    ignore = "requires 'feat_failpoints'"
+)]
 fn test_KERNEL32_IsWow64Process() {
     let result = KERNEL32_IsWow64Process(WinAPI_GetCurrentProcess());
     assert!(result.is_ok());
+    {
+        let _guard = fail::FailGuard::new("KERNEL32_IsWow64Process", "return");
+        let result = KERNEL32_IsWow64Process(WinAPI_GetCurrentProcess());
+        assert!(result.is_err());
+    }
+    {
+        let _guard = fail::FailGuard::new("WinAPI_GetProcAddress", "return");
+        let result = KERNEL32_IsWow64Process(WinAPI_GetCurrentProcess());
+        assert!(result.is_err());
+    }
+    {
+        let _guard = fail::FailGuard::new("NTDLL_RtlGetVersion::fn", "return");
+        let result = KERNEL32_IsWow64Process(WinAPI_GetCurrentProcess());
+        assert!(result.is_ok());
+    }
 }
 
 #[test]
 #[allow(non_snake_case)]
+#[serial]
+#[cfg_attr(
+    not(feature = "feat_failpoints"),
+    ignore = "requires 'feat_failpoints'"
+)]
 fn test_NTDLL_RtlGetVersion() {
     let result = NTDLL_RtlGetVersion();
     assert!(result.is_ok());
+    {
+        let _guard = fail::FailGuard::new("NTDLL_RtlGetVersion", "return");
+        let result = NTDLL_RtlGetVersion();
+        assert!(result.is_err());
+    }
+    {
+        let _guard = fail::FailGuard::new("create_OSVERSIONINFOEXW", "return");
+        let result = NTDLL_RtlGetVersion();
+        assert!(result.is_err());
+    }
+    {
+        let _guard = fail::FailGuard::new("WinAPI_GetProcAddress", "return");
+        let result = NTDLL_RtlGetVersion();
+        assert!(result.is_err());
+    }
+    {
+        let _guard = fail::FailGuard::new("NTDLL_RtlGetVersion::fn", "return");
+        let result = NTDLL_RtlGetVersion();
+        assert!(result.is_err());
+    }
 }

--- a/src/platform/windows_safe.rs
+++ b/src/platform/windows_safe.rs
@@ -564,3 +564,50 @@ fn structure_clone() {
     let ffi_clone = ffi.clone();
     assert_eq!(ffi_clone, ffi);
 }
+
+#[test]
+#[allow(non_snake_case)]
+fn test_create_OSVERSIONINFOEXW() {
+    let result = create_OSVERSIONINFOEXW();
+    assert!(result.is_ok());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_WinAPI_GetCurrentProcess() {
+    let result = WinAPI_GetCurrentProcess();
+    assert_ne!(ptr::null_mut(), result);
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_WinAPI_LoadLibrary() {
+    let result = WinAPI_LoadLibrary("");
+    assert_eq!(ptr::null_mut(), result);
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_WinOsFileVersionInfoQuery_root() {
+    let file_path = super::WinOsGetSystemDirectory()
+        .unwrap()
+        .join("kernel32.dll");
+    let file_info = super::WinOsGetFileVersionInfo(file_path).unwrap();
+
+    let result = WinOsFileVersionInfoQuery_root(&file_info);
+    assert!(result.is_ok());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_KERNEL32_IsWow64Process() {
+    let result = KERNEL32_IsWow64Process(WinAPI_GetCurrentProcess());
+    assert!(result.is_ok());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_NTDLL_RtlGetVersion() {
+    let result = NTDLL_RtlGetVersion();
+    assert!(result.is_ok());
+}

--- a/src/platform/windows_safe.rs
+++ b/src/platform/windows_safe.rs
@@ -1,6 +1,6 @@
 // spell-checker:ignore (abbrev) MSVC
 // spell-checker:ignore (API) sysname osname nodename
-// spell-checker:ignore (jargon) armv aarch
+// spell-checker:ignore (jargon) armv aarch failpoints
 // spell-checker:ignore (rust) nonminimal repr stdcall uninit
 // spell-checker:ignore (uutils) coreutils uutils
 // spell-checker:ignore (vars) mmbr mmrb

--- a/src/platform/windows_safe.rs
+++ b/src/platform/windows_safe.rs
@@ -64,9 +64,9 @@ pub struct VS_FIXEDFILEINFO {
 //#region unsafe code
 
 impl WinApiSystemInfo {
-    #[allow(non_snake_case)]
     /// Returns `wProcessorArchitecture` extracted from the [`SYSTEM_INFO`](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info) structure.
     /// <br> Refer to [`SYSTEM_INFO`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info) for more information.
+    #[allow(non_snake_case)]
     pub fn wProcessorArchitecture(&self) -> WORD {
         unsafe { self.0.u.s().wProcessorArchitecture }
     }
@@ -223,7 +223,7 @@ pub fn WinAPI_GetFileVersionInfoW<P: AsRef<PathStr>>(
 ///
 /// If the function is called from a 64-bit application, it is equivalent to the GetSystemInfo function.
 /// If the function is called from an x86 or x64 application running on a 64-bit system that does not have an Intel64 or
-//  x64 processor (such as ARM64), it will return information as if the system is x86 only if x86 emulation is supported
+/// x64 processor (such as ARM64), it will return information as if the system is x86 only if x86 emulation is supported
 /// (or x64 if x64 emulation is also supported).
 ///
 /// Wraps WinOS [`Kernel32/GetNativeSystemInfo(...)`](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getnativesysteminfo).
@@ -560,7 +560,7 @@ fn structure_clone() {
         dwFileDateLS: 0,
     };
     println!("{:?}", ffi);
-    #[allow(clippy::clone_on_copy)] // ignore `clippy::clone_on_copy` warning for direct testing
+    #[allow(clippy::clone_on_copy)] // ignore warning for direct testing of `clone()` method
     let ffi_clone = ffi.clone();
     assert_eq!(ffi_clone, ffi);
 }


### PR DESCRIPTION
As promised, [full test coverage](https://app.codecov.io/github/rivy/rs.platform-info/commit/da12b2fd80037b4928793f29513c14bda6c2b81d)!

- improves testing code coverage to 100%
- includes:
  - test polish
  - fail_point instrumentation
  - serialization of all tests using fail_point manipulation (relative to each other and all other tests)
    - b/c fail_points are global/shared structures and RACY
  - `function_name` macros used to standardize naming of fail_points

ToDO?: reduce fail_point configuration and use boilerplate code with macro/macros?