### PR TITLE
add support for Illumos

### DIFF
--- a/src/lib_impl.rs
+++ b/src/lib_impl.rs
@@ -52,6 +52,8 @@ const HOST_OS_NAME: &str = if cfg!(all(
     "Fuchsia"
 } else if cfg!(target_os = "redox") {
     "Redox"
+} else if cfg!(target_os = "illumos") {
+    "Illumos"
 } else {
     "unknown"
 };

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -115,8 +115,10 @@ impl Debug for UTSName {
             .field("release", &oss_from_cstr(&self.0.release))
             .field("version", &oss_from_cstr(&self.0.version))
             .field("machine", &oss_from_cstr(&self.0.machine));
-        // BSD-like platforms are missing the domainname field
+        // The domainname field is not part of the POSIX standard but a GNU extension. Therefor
+        // BSD-like platforms and Illumos are missing the domainname field.
         #[cfg(not(any(
+            target_os = "illumos",
             target_os = "macos",
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -147,8 +149,10 @@ impl PartialEq for UTSName {
                 other.0.version,
                 other.0.machine,
             );
-        // BSD-like platforms are missing the domainname field
+        // The domainname field is not part of the POSIX standard but a GNU extension. Therefor
+        // BSD-like platforms and Illumos are missing the domainname field.
         #[cfg(not(any(
+            target_os = "illumos",
             target_os = "macos",
             target_os = "dragonfly",
             target_os = "freebsd",


### PR DESCRIPTION
This commit introduces support for Illumos, an (Open) Solaris derivative. 

`uname -o` on Illumos returns `illumos`.

It also clarifies the documentation a bit on why the domainname field is missing for OS'es like the BSD's and Illumos.