### PR TITLE
Fix `cargo clippy` compaints (*allow* clippy::redundant_clone)

### DIFF
--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -214,6 +214,7 @@ fn test_osname() {
 fn structure_clone() {
     let info = PlatformInfo::new().unwrap();
     println!("{:?}", info);
+    #[allow(clippy::redundant_clone)] // ignore `clippy::redundant_clone` warning for direct testing
     let info_copy = info.clone();
     assert_eq!(info_copy, info);
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -750,6 +750,7 @@ fn test_known_winos_names() {
 fn structure_clone() {
     let info = PlatformInfo::new().unwrap();
     println!("{:?}", info);
+    #[allow(clippy::redundant_clone)] // ignore `clippy::redundant_clone` warning for direct testing
     let info_copy = info.clone();
     assert_eq!(info_copy, info);
 
@@ -760,6 +761,7 @@ fn structure_clone() {
         release: 4,
     };
     println!("{:?}", mmbr);
+    #[allow(clippy::redundant_clone)] // ignore `clippy::redundant_clone` warning for direct testing
     let mmbr_copy = mmbr.clone();
     assert_eq!(mmbr_copy, mmbr);
 
@@ -767,6 +769,7 @@ fn structure_clone() {
         data: vec![1, 2, 3, 4],
     };
     println!("{:?}", fvi);
+    #[allow(clippy::redundant_clone)] // ignore `clippy::redundant_clone` warning for direct testing
     let fvi_copy = fvi.clone();
     assert_eq!(fvi_copy, fvi);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -48,6 +48,7 @@ fn platform_no_invisible_contents() -> Result<(), String> {
 #[test]
 fn platform_clone() -> Result<(), String> {
     let info = PlatformInfo::new().unwrap();
+    #[allow(clippy::redundant_clone)] // ignore `clippy::redundant_clone` warning for direct testing
     let info_copy = info.clone();
     println!("{:?}", info);
     assert_eq!(info_copy, info);


### PR DESCRIPTION
* allows clippy::redundant_clone for code directly testing clone functionality