### PR TITLE
"illumos" is officially typeset with a lower-case "i"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "platform-info"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Alex Lyon <arcterus@mail.com>"]
 edition = "2018"
 description = "A simple cross-platform interface to get info about a system"

--- a/src/lib_impl.rs
+++ b/src/lib_impl.rs
@@ -53,7 +53,7 @@ const HOST_OS_NAME: &str = if cfg!(all(
 } else if cfg!(target_os = "redox") {
     "Redox"
 } else if cfg!(target_os = "illumos") {
-    "Illumos"
+    "illumos"
 } else {
     "unknown"
 };

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -116,7 +116,7 @@ impl Debug for UTSName {
             .field("version", &oss_from_cstr(&self.0.version))
             .field("machine", &oss_from_cstr(&self.0.machine));
         // The domainname field is not part of the POSIX standard but a GNU extension. Therefor
-        // BSD-like platforms and Illumos are missing the domainname field.
+        // BSD-like platforms and illumos are missing the domainname field.
         #[cfg(not(any(
             target_os = "illumos",
             target_os = "macos",
@@ -150,7 +150,7 @@ impl PartialEq for UTSName {
                 other.0.machine,
             );
         // The domainname field is not part of the POSIX standard but a GNU extension. Therefor
-        // BSD-like platforms and Illumos are missing the domainname field.
+        // BSD-like platforms and illumos are missing the domainname field.
         #[cfg(not(any(
             target_os = "illumos",
             target_os = "macos",


### PR DESCRIPTION
Hi!  I was trying to build Synapse (the Matrix server) which now depends on this `platform-info` crate.  I thought I was going to have to port it myself, but I was excited to see @siepkes already did that!

I was hoping to do two (hopefully small!) things with this PR:

- correct the case of our OS name string: **illumos** is always typeset in lower case, not with a capital **I**
- get a 2.0.2 release published with illumos support so that we can use it from other crates, etc