### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           report=${COVERAGE_REPORT_FILE}
           outputs report
       - name: Upload coverage results (to Codecov.io)
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         # if: steps.vars.outputs.HAS_CODECOV_TOKEN
         with:
           # token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Reverts uutils/platform-info#57 because they tagged the version prematurely, see https://github.com/codecov/codecov-action/issues/1089