### PR TITLE
Use "from" instead of "try_from"

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -420,10 +420,10 @@ fn mmbr_from_file_version(
 ) -> Result<MmbrVersion, WinOSError> {
     let info = WinOsFileVersionInfoQuery_root(&file_version_info)?;
     Ok(MmbrVersion {
-        major: DWORD::try_from(HIWORD(info.dwProductVersionMS))?,
-        minor: DWORD::try_from(LOWORD(info.dwProductVersionMS))?,
-        build: DWORD::try_from(HIWORD(info.dwProductVersionLS))?,
-        release: DWORD::try_from(LOWORD(info.dwProductVersionLS))?,
+        major: DWORD::from(HIWORD(info.dwProductVersionMS)),
+        minor: DWORD::from(LOWORD(info.dwProductVersionMS)),
+        build: DWORD::from(HIWORD(info.dwProductVersionLS)),
+        release: DWORD::from(LOWORD(info.dwProductVersionLS)),
     })
 }
 


### PR DESCRIPTION
This PR replaces some `try_from` with `from` in order to fix warnings from [unnecessary_fallible_conversions](https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_fallible_conversions) lint.