### PR TITLE
ci: fix "unexpected input 'command'" warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.3
       - uses: DavidAnson/markdownlint-cli2-action@v15
         with:
-          command: fix
+          fix: true
           globs: |
             *.md
             docs/src/**/*.md


### PR DESCRIPTION
This PR fixes the "Unexpected input(s) 'command', valid inputs are ['config', 'fix', 'globs', 'separator']" warnings from `markdownlint-cli2-action`.