### PR TITLE
clippy: use char instead of closure

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -542,7 +542,7 @@ fn test_sysname() {
 fn test_nodename_no_trailing_NUL() {
     let info = PlatformInfo::new().unwrap();
     let nodename = info.nodename().to_string_lossy();
-    let trimmed = nodename.trim().trim_end_matches(|c| c == '\0');
+    let trimmed = nodename.trim().trim_end_matches('\0');
     println!("nodename=[{}]'{}'", nodename.len(), nodename);
     assert_eq!(nodename, trimmed);
 }


### PR DESCRIPTION
This PR fixes a warning from the [manual_pattern_char_comparison](https://rust-lang.github.io/rust-clippy/master/index.html#/manual_pattern_char_comparison) lint on Windows.