### PR TITLE
add support for Solaris

### DIFF
--- a/src/lib_impl.rs
+++ b/src/lib_impl.rs
@@ -54,6 +54,8 @@ const HOST_OS_NAME: &str = if cfg!(all(
     "Redox"
 } else if cfg!(target_os = "illumos") {
     "illumos"
+} else if cfg!(target_os = "solaris") {
+    "solaris"
 } else {
     "unknown"
 };

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -116,10 +116,11 @@ impl Debug for UTSName {
             .field("version", &oss_from_cstr(&self.0.version))
             .field("machine", &oss_from_cstr(&self.0.machine));
         // The domainname field is not part of the POSIX standard but a GNU extension. Therefor
-        // BSD-like platforms and illumos are missing the domainname field.
+        // BSD-like platforms and solaris/illumos are missing the domainname field.
         #[cfg(not(any(
             target_os = "aix",
             target_os = "illumos",
+            target_os = "solaris",
             target_os = "macos",
             target_os = "dragonfly",
             target_os = "freebsd",
@@ -151,10 +152,11 @@ impl PartialEq for UTSName {
                 other.0.machine,
             );
         // The domainname field is not part of the POSIX standard but a GNU extension. Therefor
-        // BSD-like platforms and illumos are missing the domainname field.
+        // BSD-like platforms and solaris/illumos are missing the domainname field.
         #[cfg(not(any(
             target_os = "aix",
             target_os = "illumos",
+            target_os = "solaris",
             target_os = "macos",
             target_os = "dragonfly",
             target_os = "freebsd",


### PR DESCRIPTION
This change adds support for Solaris (very similar to #48).

`cargo test` is green, was complaining about unknown field `self.0.domainname` before.
