### PR TITLE
clippy: fix warning from `needless_doctest_main`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ platform-info = "2"
 
 ```rust
 */
-#![doc = include_str!("../examples/ex.rs")]
+#![cfg_attr(doc, doc = include_str!("../examples/ex.rs"))]
 /*!
 ```
 

--- a/src/platform/windows_safe.rs
+++ b/src/platform/windows_safe.rs
@@ -482,7 +482,7 @@ pub fn KERNEL32_IsWow64Process(process: HANDLE) -> Result<bool, WinOSError> {
         )));
     }
 
-    let func: extern "stdcall" fn(HANDLE, *mut BOOL) -> BOOL =
+    let func: extern "system" fn(HANDLE, *mut BOOL) -> BOOL =
         unsafe { mem::transmute(func as *const ()) };
 
     let mut is_wow64: BOOL = FALSE;
@@ -516,7 +516,7 @@ pub fn NTDLL_RtlGetVersion() -> Result<OSVERSIONINFOEXW, WinOSError> {
             symbol_name, module_file
         )));
     }
-    let func: extern "stdcall" fn(*mut RTL_OSVERSIONINFOEXW) -> NTSTATUS =
+    let func: extern "system" fn(*mut RTL_OSVERSIONINFOEXW) -> NTSTATUS =
         unsafe { mem::transmute(func as *const ()) };
 
     let mut os_version_info = match create_OSVERSIONINFOEXW() {


### PR DESCRIPTION
This PR fixes a warning from the [needless_doctest_main](https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main) lint.