### PR TITLE
Change "solaris" to "Solaris"

### DIFF
--- a/src/lib_impl.rs
+++ b/src/lib_impl.rs
@@ -96,7 +96,7 @@ const HOST_OS_NAME: &str = if cfg!(all(
 } else if cfg!(target_os = "illumos") {
     "illumos"
 } else if cfg!(target_os = "solaris") {
-    "solaris"
+    "Solaris"
 } else if cfg!(target_os = "cygwin") {
     "Cygwin"
 } else {


### PR DESCRIPTION
While reviewing https://github.com/uutils/platform-info/pull/102 I noticed we set  `HOST_OS_NAME` to `solaris` on Solaris. I think it should be `Solaris`.